### PR TITLE
fix: module resolution

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,10 @@ import type { Config } from 'jest'
 
 const config: Config = {
   verbose: true,
-  testMatch: ['**/tests/**.(test).@(ts)']
+  testMatch: ['**/tests/**.(test).@(ts)'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 }
 
 export default config

--- a/plugin/Authentication.ts
+++ b/plugin/Authentication.ts
@@ -3,7 +3,7 @@ import type { FirebaseApp, FirebaseOptions } from 'firebase/app'
 import type { Auth, User } from 'firebase/auth'
 import type { Page } from '@playwright/test'
 
-import { addFirebaseScript, getToken } from './auth.setup'
+import { addFirebaseScript, getToken } from './auth.setup.js'
 
 // Since these are declared in browser modules, it's hard to understand what the types should be.
 // As such we're defining what shape we're expecting.


### PR DESCRIPTION
There's an issue with proper module resolution - node requires the [extension be present in module includes](https://nodejs.org/api/esm.html#mandatory-file-extensions) to ensure proper operation, typescript doesn't add it by default, and jest complained when i added it. This fix includes the extension and fixes the Jest complaints when testing.

Fixes #40 