### PR TITLE
chore: update imported firebase version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,7 @@ export default function playwrightFirebasePlugin(
     PlaywrightTestArgs & PlaywrightTestOptions,
     PlaywrightWorkerArgs & PlaywrightWorkerOptions
   >,
-  version = '9.6.10'
+  version = '10.5.0'
 ) {
   return base.extend<{ auth: Authentication } & AuthenticationParams>({
     UID: [UID, { option: true }],


### PR DESCRIPTION
Resolved #88 
This will use the Firebase version of 10.5.0, the most recent one when importing the files from gstatic on the browser window. I've tested this with the demo repo, importing this branch and executing it. The url endpoint was indeed changed when running `npx playwright show-report` 
<img width="891" alt="Screenshot 2023-10-16 at 15 56 12" src="https://github.com/nearform/playwright-firebase/assets/85499621/e9c4e313-6e9f-4ad9-be2a-0d8279f68010">
