### PR TITLE
fix: jest mock restore changes

### DIFF
--- a/tests/Authentication.test.ts
+++ b/tests/Authentication.test.ts
@@ -17,10 +17,10 @@ const TEST_SERVICE_ACCOUNT = {}
 const TEST_VERSION = 'ver'
 const mockedStatusCode = jest.fn()
 
-const mockedEvalute = jest.fn()
+const mockedEvaluate = jest.fn()
 const mockedAddScriptTag = jest.fn()
 const pageMock: Page = {
-  evaluate: mockedEvalute,
+  evaluate: mockedEvaluate,
   addScriptTag: mockedAddScriptTag
 } as unknown as Page
 
@@ -39,13 +39,12 @@ const mockedResponse = () =>
 
 describe('Authentication Class tests', () => {
   beforeEach(() => {
-    // mockedEvalute.mockReset()
     jest.spyOn(authSetup, 'getToken').mockReturnValue(Promise.resolve('hello'))
     jest.spyOn(global, 'fetch').mockImplementation(mockedResponse)
     mockedStatusCode.mockReturnValue(200)
   })
   afterEach(() => {
-    jest.restoreAllMocks()
+    jest.clearAllMocks()
   })
   test('Authentication class initialised w/ log in/out functions', () => {
     const Auth = generateAuth()
@@ -56,7 +55,7 @@ describe('Authentication Class tests', () => {
   test('Logging in calls the evaluate function of the page + addScriptTag', async () => {
     const Auth = generateAuth()
     await Auth.login(pageMock)
-    expect(mockedEvalute).toHaveBeenCalled()
+    expect(mockedEvaluate).toHaveBeenCalled()
     expect(mockedAddScriptTag).toHaveBeenCalledTimes(3)
   })
   test('Bad version number throws', async () => {
@@ -70,7 +69,7 @@ describe('Authentication Class tests', () => {
     const Auth = generateAuth()
     Auth.userSet = true
     await Auth.login(pageMock)
-    expect(mockedEvalute).not.toHaveBeenCalled()
+    expect(mockedEvaluate).not.toHaveBeenCalled()
   })
   test('Logging out resets user', async () => {
     const Auth = generateAuth()


### PR DESCRIPTION
Fixes #90 
A recent Jest update had some reverted changes on how `jest.restoreAllMocks()` works. Originally, `restoreAllMocks` would both clear the mock state(e.g. no. of calls), and is what we used to clear the `mockEvaluate` mock. However the new updates have reverted this due to breaking changes. More info [here](https://github.com/jestjs/jest/pull/14429) on the breaking changes. This is why dependabot was unable to pass the tests. 

I've modified the test to now `clearAllMocks` instead of `restoreAllMocks` which is more precise. `restoreAllMocks` (previously) was a catch-all that would restore the original implementation (restore), replace the mock implementation with an empty function (reset), and clear the mock state for both mock functions and spies (clear). Now it only works on spies. 

For more info, see the docs [here](https://jestjs.io/docs/next/mock-function-api#mockfnmockrestore). You can see how the abilities of each `clear -> reset -> restore` are inherited from left to right. 