### PR TITLE
Fix/recursive import

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-./example

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,6 @@
       "name": "example",
       "version": "0.1.0",
       "dependencies": {
-        "@nearform/playwright-firebase": "file:..",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -31,6 +30,7 @@
     "..": {
       "name": "@nearform/playwright-firebase",
       "version": "1.1.1",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.3"
@@ -3165,10 +3165,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-    },
-    "node_modules/@nearform/playwright-firebase": {
-      "resolved": "..",
-      "link": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@nearform/playwright-firebase": "file:..",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/example/test-examples/auth.setup.ts
+++ b/example/test-examples/auth.setup.ts
@@ -1,4 +1,4 @@
-import playwrightFirebasePlugin from '@nearform/playwright-firebase'
+import playwrightFirebasePlugin from '../../index'
 import { test as base } from '@playwright/test'
 import dotenv from 'dotenv'
 dotenv.config({ path: './.env' })


### PR DESCRIPTION
Fixing the recursive import. Beforehand we were importing the parent module which did not ignore the sample module thereby making many many node modules. I'm instead using a local import. 

I decided to not use npmignore, as we have the `files` which whitelists only the `dist` folder so the examples will not be packaged up. 