### PR TITLE
fix: remove .js suffix on import

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import type {
   PlaywrightWorkerArgs,
   PlaywrightWorkerOptions
 } from '@playwright/test'
-import { Authentication } from './plugin/Authentication.js'
+import { Authentication } from './plugin/Authentication'
 
 export type Credentials = {
   auth: Authentication

--- a/plugin/Authentication.ts
+++ b/plugin/Authentication.ts
@@ -3,7 +3,7 @@ import type { FirebaseApp, FirebaseOptions } from 'firebase/app'
 import type { Auth, User } from 'firebase/auth'
 import type { Page } from '@playwright/test'
 
-import { addFirebaseScript, getToken } from './auth.setup.js'
+import { addFirebaseScript, getToken } from './auth.setup'
 
 // Since these are declared in browser modules, it's hard to understand what the types should be.
 // As such we're defining what shape we're expecting.


### PR DESCRIPTION
Fixes #100 
Seems to work now. Must've changes tsconfig in the past, remember it not being supported. Tested the example and it still works. 