### PR TITLE
Fixes: require() of ES Module not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # @nearform/playwright-firebase
 
+> [!NOTE]  
+> This is an ESM only package, please make sure your usage follows the rules of ESM 
+> User the following [guide](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#pure-esm-package) to learn more
+
 Tidy way to authenticate Playwright E2E tests on Firebase.
 
 Install using npm:

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import type {
   PlaywrightWorkerArgs,
   PlaywrightWorkerOptions
 } from '@playwright/test'
-import { Authentication } from './plugin/Authentication'
+import { Authentication } from './plugin/Authentication.js'
 
 export type Credentials = {
   auth: Authentication

--- a/plugin/Authentication.ts
+++ b/plugin/Authentication.ts
@@ -3,7 +3,7 @@ import type { FirebaseApp, FirebaseOptions } from 'firebase/app'
 import type { Auth, User } from 'firebase/auth'
 import type { Page } from '@playwright/test'
 
-import { addFirebaseScript, getToken } from './auth.setup'
+import { addFirebaseScript, getToken } from './auth.setup.js'
 
 // Since these are declared in browser modules, it's hard to understand what the types should be.
 // As such we're defining what shape we're expecting.


### PR DESCRIPTION
### Draft Notes

If we wish to let users know that this is a ESM Package then the current solution should be just fine. 

If not then the package needs to export hybrid for both CJS and ESM users. 



Closes #179