### PR TITLE
Fix (Auth): Flaky Sign-In

### DIFF
--- a/plugin/Authentication.ts
+++ b/plugin/Authentication.ts
@@ -50,6 +50,16 @@ export class Authentication {
     }
     const token: string = await getToken(this.serviceAccount, this.UID)
     await addFirebaseScript(page, this.version)
+
+    const firebaseModuleLoaded = await page
+      .mainFrame()
+      .waitForFunction('window.firebase !== undefined')
+
+    if (!firebaseModuleLoaded) {
+      console.log('Error initialising and signing in')
+      return
+    }
+
     try {
       await page.evaluate(
         async ({ token, config }) => {

--- a/plugin/Authentication.ts
+++ b/plugin/Authentication.ts
@@ -24,6 +24,14 @@ declare global {
   }
 }
 
+export const errors = {
+  FIREBASE_VERSION_ERROR:
+    'Bad Request: Please ensure your version number is correct.',
+  FIREBASE_MODULE_LOAD_ERROR:
+    'Failed to load firebase module script. Please check your network settings',
+  FIREBASE_INIT_ERROR: 'Error initialising and signing in'
+}
+
 export class Authentication {
   userSet = false
 
@@ -53,11 +61,10 @@ export class Authentication {
 
     const firebaseModuleLoaded = await page
       .mainFrame()
-      .waitForFunction('window.firebase !== undefined')
+      .waitForFunction('window.firebase !== undefined', {})
 
     if (!firebaseModuleLoaded) {
-      console.log('Error initialising and signing in')
-      return
+      throw new Error(errors.FIREBASE_MODULE_LOAD_ERROR)
     }
 
     try {
@@ -74,7 +81,7 @@ export class Authentication {
       )
       this.userSet = true
     } catch {
-      console.log('Error initialising and signing in')
+      throw new Error(errors.FIREBASE_INIT_ERROR)
     }
   }
 

--- a/plugin/auth.setup.ts
+++ b/plugin/auth.setup.ts
@@ -31,6 +31,10 @@ async function addFirebaseScript(page: Page, version: string) {
     url: `https://www.gstatic.com/firebasejs/${version}/firebase-app.js`,
     type: 'module'
   })
+
+  // Note: Will resolve as soon as the content is injected into the frame
+  // and will not wait for the scripts to be loaded in this case.
+  // The above caching may or maynot work based on network conditions
   await page.addScriptTag({
     content: `
         import * as Auth from 'https://www.gstatic.com/firebasejs/${version}/firebase-auth.js';

--- a/tests/Authentication.test.ts
+++ b/tests/Authentication.test.ts
@@ -19,9 +19,15 @@ const mockedStatusCode = jest.fn()
 
 const mockedEvaluate = jest.fn()
 const mockedAddScriptTag = jest.fn()
+const mockedMainFrameFuncs = {
+  waitForFunction: jest.fn().mockReturnValue(true)
+}
+const mockedMainFrame = jest.fn(() => mockedMainFrameFuncs)
+
 const pageMock: Page = {
   evaluate: mockedEvaluate,
-  addScriptTag: mockedAddScriptTag
+  addScriptTag: mockedAddScriptTag,
+  mainFrame: mockedMainFrame
 } as unknown as Page
 
 const generateAuth = () => {


### PR DESCRIPTION
Adds a function to wait for the script to execute since in case of using `content` the promises resolves as soon as the content is injected, there might be a race condition between the execution of the content and the execution of `page.evaluate` 

It's rare as the difference is very rare and was only able to reproduce it 2 times out of 20 executions.  

Closes #180

### References
https://playwright.dev/docs/api/class-page#page-add-script-tag