### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "firebase": "^10.2.0",
         "firebase-admin": "^12.0.0",
-        "husky": "^9.0.6",
+        "husky": "^9.0.11",
         "jest": "^29.5.0",
         "lint-staged": "^15.0.1",
         "playwright": "^1.37.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "firebase": "^10.2.0",
     "firebase-admin": "^12.0.0",
-    "husky": "^9.0.6",
+    "husky": "^9.0.11",
     "jest": "^29.5.0",
     "lint-staged": "^15.0.1",
     "playwright": "^1.37.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)