### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "lint": "eslint \"*.{ts,tsx}\"",
-    "prepare": "husky install && npm run build",
+    "prepare": "husky && npm run build",
     "test": "jest",
     "test:e2e": "cd tests/helpers/test-site && npm ci && npx playwright test",
     "test:pw": "npx playwright test",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)