### PR TITLE
fix: export AuthenticationParams interface

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ export type Credentials = {
   options: FirebaseOptions
 }
 
-interface AuthenticationParams {
+export interface AuthenticationParams {
   UID: string
   options: FirebaseOptions
   serviceAccount: ServiceAccount


### PR DESCRIPTION
Missing export causes TS to complain: 

Exported variable 'test' has or is using name 'AuthenticationParams' from external module "<my project>/node_modules/@nearform/playwright-firebase/dist/index" but cannot be named.

