### PR TITLE
chore: migrate to OIDC publishing for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,22 +16,17 @@ on:
 
 jobs:
   release:
+    runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write
-    runs-on: ubuntu-latest
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
           semver: ${{ github.event.inputs.semver }}
           commit-message: 'chore: release {version}'
-          npm-token: >-
-            ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] ||
-            secrets.NPM_TOKEN }}
-          optic-token: >-
-            ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] ||
-            secrets.OPTIC_TOKEN }}
           build-command: npm ci
-          provenance: true
+          publish-mode: oidc


### PR DESCRIPTION
- Add OIDC trusted publishing support
- Remove npm token and optic-token dependencies
- Add production environment and required permissions
- Update to publish-mode: oidc

This migration eliminates the need for npm tokens and provides enhanced security through GitHub's identity provider.