### PR TITLE
chore(deps): bump minor + patch dependencies (verified, tests green)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,30 +48,30 @@
   },
   "homepage": "https://github.com/nearform/playwright-firebase#readme",
   "devDependencies": {
-    "@babel/core": "^7.21.8",
-    "@babel/preset-env": "^7.21.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@commitlint/cli": "^20.1.0",
-    "@commitlint/config-conventional": "^20.0.0",
-    "@jest/globals": "^30.0.0",
-    "@playwright/test": "^1.37.1",
-    "@types/node": "^25.0.3",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "babel-jest": "^30.0.0",
-    "eslint": "^8.47.0",
-    "eslint-config-prettier": "^10.0.1",
-    "eslint-plugin-prettier": "^5.0.0",
-    "firebase": "^12.0.0",
-    "firebase-admin": "^13.0.0",
-    "husky": "^9.0.11",
-    "jest": "^29.5.0",
-    "lint-staged": "^16.0.0",
-    "playwright": "^1.37.1",
-    "prettier": "^3.0.1",
-    "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "@babel/core": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
+    "@babel/preset-typescript": "^7.29.7",
+    "@commitlint/cli": "^20.5.3",
+    "@commitlint/config-conventional": "^20.5.3",
+    "@jest/globals": "^30.4.1",
+    "@playwright/test": "^1.61.1",
+    "@types/node": "^25.9.4",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "babel-jest": "^30.4.1",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.6",
+    "firebase": "^12.15.0",
+    "firebase-admin": "^13.10.0",
+    "husky": "^9.1.7",
+    "jest": "^29.7.0",
+    "lint-staged": "^16.4.0",
+    "playwright": "^1.61.1",
+    "prettier": "^3.9.4",
+    "ts-jest": "^29.4.11",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "firebase-admin": "^13.0.0"
@@ -80,6 +80,6 @@
     "*.{js,jsx}": "eslint --cache --fix"
   },
   "dependencies": {
-    "dotenv": "^17.2.0"
+    "dotenv": "^17.4.2"
   }
 }


### PR DESCRIPTION
Batches available **minor + patch** upgrades (25 packages, no majors) into one PR. Baseline `npm test` green **before**, and green **after** the bump. All available minor/patch upgrades. Companion PR adds dependabot minor/patch grouping. For human review + merge — not merging anything.